### PR TITLE
Add tests for response formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@
 ---
 ### Maintainer
 - Name : Edward Lee
+
+## ✅ Running Tests
+
+Install dependencies and run `pytest`:
+
+```bash
+pip install -r requirements.txt
+pip install pytest
+pytest
+```

--- a/tests/test_response_formatter.py
+++ b/tests/test_response_formatter.py
@@ -1,0 +1,35 @@
+import re
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.utils.response_formatter import pack_response
+
+
+def test_pack_response_includes_keys():
+    data = [{'id': 1}, {'id': 2}]
+    result = pack_response('data', data, count_key='count')
+    assert result['rsp_code'] == '00000'
+    assert result['rsp_msg'] == '정상처리'
+    assert result['data'] == data
+    assert result['count'] == len(data)
+    # search_timestamp is included and is numeric string
+    assert re.match(r"^\d{14}$", result['search_timestamp'])
+
+
+try:
+    from fastapi.testclient import TestClient
+    from app.main import app
+except Exception:  # httpx may not be installed
+    TestClient = None
+    app = None
+
+
+@pytest.mark.skipif(TestClient is None, reason="TestClient unavailable")
+def test_root_endpoint():
+    client = TestClient(app)
+    response = client.get('/')
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello from Custom MyData API"}


### PR DESCRIPTION
## Summary
- create `tests/` directory
- add `tests/test_response_formatter.py` with unit test and optional root endpoint test
- document how to run pytest in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fbf0cb8d48329b6b909d481dd227d