### PR TITLE
Update prepaid filters to use authenticated user

### DIFF
--- a/app/routers/prepaid.py
+++ b/app/routers/prepaid.py
@@ -34,7 +34,7 @@ def get_prepaid_balance(
     db: Session = Depends(get_db)
     ):
     row = db.query(PrepaidBalance).filter(
-        PrepaidBalance.user_id == "user123",  # 필요 시 token 또는 user_id 추출
+        PrepaidBalance.user_id == current_user,  # 필요 시 token 또는 user_id 추출
         PrepaidBalance.pp_id == req.pp_id,
         PrepaidBalance.search_timestamp == req.search_timestamp
     ).first()
@@ -61,7 +61,7 @@ def get_prepaid_approvals(
     db: Session = Depends(get_db)
     ):
     query = db.query(PrepaidApproval).filter(
-        PrepaidApproval.user_id == "user123",
+        PrepaidApproval.user_id == current_user,
         PrepaidApproval.approved_dtime >= req.from_date,
         PrepaidApproval.approved_dtime <= req.to_date
     )


### PR DESCRIPTION
## Summary
- use the current authenticated user when querying prepaid balances and approvals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fbef8834c83299966394737529491