### PR TITLE
Fix duplicate import in card_approval_domestic_response

### DIFF
--- a/app/schemas/card_approval_domestic_response.py
+++ b/app/schemas/card_approval_domestic_response.py
@@ -1,5 +1,4 @@
 from pydantic import BaseModel
-from pydantic import BaseModel
 from typing import List, Optional
 from app.schemas.card_approval_domestic import CardApprovalDomesticSchema
 


### PR DESCRIPTION
## Summary
- remove duplicate `BaseModel` import in `card_approval_domestic_response.py`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fbf0ba1e083298c38dbb59d68e690