### PR TITLE
Fix wrong user filter in prepaid router

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,7 +1,7 @@
 # 로그인용 라우터
 
 # app/routers/auth.py
-from fastapi import APIRouter, HTTPException, Form, Depends, HTTPException, status
+from fastapi import APIRouter, HTTPException, Form, Depends, status
 from sqlalchemy.orm import Session
 from app.core.database import get_db
 from app.models.user import User

--- a/app/routers/prepaid.py
+++ b/app/routers/prepaid.py
@@ -34,7 +34,7 @@ def get_prepaid_balance(
     db: Session = Depends(get_db)
     ):
     row = db.query(PrepaidBalance).filter(
-        PrepaidBalance.user_id == "user123",  # 필요 시 token 또는 user_id 추출
+        PrepaidBalance.user_id == current_user,
         PrepaidBalance.pp_id == req.pp_id,
         PrepaidBalance.search_timestamp == req.search_timestamp
     ).first()
@@ -61,7 +61,7 @@ def get_prepaid_approvals(
     db: Session = Depends(get_db)
     ):
     query = db.query(PrepaidApproval).filter(
-        PrepaidApproval.user_id == "user123",
+        PrepaidApproval.user_id == current_user,
         PrepaidApproval.approved_dtime >= req.from_date,
         PrepaidApproval.approved_dtime <= req.to_date
     )


### PR DESCRIPTION
## Summary
- filter by the authenticated user in prepaid routes instead of a hardcoded id
- clean up duplicate import in auth router

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684fb9d359a08329936a8e6fdc3deb5d